### PR TITLE
投稿情報編集機能

### DIFF
--- a/app/controllers/cafetypes_controller.rb
+++ b/app/controllers/cafetypes_controller.rb
@@ -1,6 +1,6 @@
 class CafetypesController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   before_action :set_cafetype, except: [:index, :new, :create]
-  before_action :authenticate_user!, expect: [:index, :show]
   before_action :move_to_index, only: [:edit, :update, :destroy]
   
   def index

--- a/app/controllers/cafetypes_controller.rb
+++ b/app/controllers/cafetypes_controller.rb
@@ -22,6 +22,20 @@ class CafetypesController < ApplicationController
     @cafetype = Cafetype.find(params[:id])
   end
 
+  def edit
+    @cafetype = Cafetype.find(params[:id])
+  end
+  
+  def update
+    @cafetype = Cafetype.find(params[:id])
+    if @cafetype.update(cafetype_params)
+      redirect_to cafetype_path
+    else
+      render :edit
+    end
+  end
+
+
 
   private
   def cafetype_params

--- a/app/controllers/cafetypes_controller.rb
+++ b/app/controllers/cafetypes_controller.rb
@@ -1,8 +1,10 @@
 class CafetypesController < ApplicationController
-  before_action :authenticate_user!, only:[:new]
+  before_action :set_cafetype, except: [:index, :new, :create]
+  before_action :authenticate_user!, expect: [:index, :show]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
   
   def index
-    @cafetypes = Cafetype.all.order('created_at DESC')
+    @cafetypes = Cafetype.includes(:user).order('created_at DESC')
   end
   
   def new
@@ -19,15 +21,15 @@ class CafetypesController < ApplicationController
   end
 
   def show
-    @cafetype = Cafetype.find(params[:id])
+   
   end
 
   def edit
-    @cafetype = Cafetype.find(params[:id])
+    
   end
   
   def update
-    @cafetype = Cafetype.find(params[:id])
+    
     if @cafetype.update(cafetype_params)
       redirect_to cafetype_path
     else
@@ -40,6 +42,16 @@ class CafetypesController < ApplicationController
   private
   def cafetype_params
     params.require(:cafetype).permit(:shop_name, :image, :catch_copy, :prefecture_id, :city, :block_number, :wifi_id, :power_supply_id, :capacity_id, :toilet_place_id, :cafe_price).merge(user_id: current_user.id)
+  end
+
+  def set_cafetype
+    @cafetype = Cafetype.find(params[:id])
+  end
+
+  def move_to_index
+    unless current_user == @cafetype.user
+      redirect_to root_path
+    end
   end
 
 end

--- a/app/views/cafetypes/edit.html.erb
+++ b/app/views/cafetypes/edit.html.erb
@@ -1,8 +1,9 @@
 <div class="main">
   <div class="inner">
     <div class="form__wrapper">
-      <h2 class="page-heading">プロトタイプ編集</h2>
+      <h2 class="page-heading">投稿店舗の編集</h2>
       <%# 部分テンプレートでフォームを表示する %>
+        <%= render partial: "form", locals:{ cafetype: @cafetype} %>
     </div>
   </div>
 </div>

--- a/app/views/cafetypes/edit.html.erb
+++ b/app/views/cafetypes/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">投稿店舗の編集</h2>
-      <%# 部分テンプレートでフォームを表示する %>
+    
         <%= render partial: "form", locals:{ cafetype: @cafetype} %>
     </div>
   </div>

--- a/app/views/cafetypes/index.html.erb
+++ b/app/views/cafetypes/index.html.erb
@@ -1,6 +1,6 @@
 <main class="main">
   <div class="inner">
-    <%# ログインしているときは以下を表示する %>
+   
     <% if user_signed_in? %>
       <div class="greeting">
        <p>こんにちは、
@@ -9,9 +9,9 @@
       </div>
       <% else %>
       <% end %>
-    <%# // ログインしているときは上記を表示する %>
+   
     <div class="card__wrapper">
-      <%# 投稿機能実装後、部分テンプレートでプロトタイプ投稿一覧を表示する %>
+    
       <%= render partial: 'cafetype', collection: @cafetypes %>
     </div>
   </div>

--- a/app/views/cafetypes/new.html.erb
+++ b/app/views/cafetypes/new.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">新規カフェ投稿</h2>
-        <%# 部分テンプレートでフォームを表示する %>
+        
          <%= render partial: "form", locals:{ cafetype: @cafetype} %>
     </div>
   </div>

--- a/app/views/cafetypes/show.html.erb
+++ b/app/views/cafetypes/show.html.erb
@@ -4,11 +4,11 @@
       <p class="prototype__hedding">
         <%= @cafetype.shop_name %>
       </p>
-      <%= link_to "by プロトタイプの投稿者", root_path, class: :prototype__user %>
+      <%= link_to "by 店舗情報の投稿者", root_path, class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
-      <% if user_signed_in? && current_user.id == @cafetype.user_id%>
+      <% if current_user == @cafetype.user %>
         <div class="prototype__manage">
-          <%= link_to "編集する", edit_cafetype_path(@cafetype.id), class: :prototype__btn %>
+          <%= link_to "編集する", edit_cafetype_path(@cafetype), class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
         <% end %>

--- a/app/views/cafetypes/show.html.erb
+++ b/app/views/cafetypes/show.html.erb
@@ -8,7 +8,7 @@
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       <% if user_signed_in? && current_user.id == @cafetype.user_id%>
         <div class="prototype__manage">
-          <%= link_to "編集する", root_path, class: :prototype__btn %>
+          <%= link_to "編集する", edit_cafetype_path(@cafetype.id), class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
         <% end %>

--- a/app/views/cafetypes/show.html.erb
+++ b/app/views/cafetypes/show.html.erb
@@ -5,14 +5,14 @@
         <%= @cafetype.shop_name %>
       </p>
       <%= link_to "by 店舗情報の投稿者", root_path, class: :prototype__user %>
-      <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
+      
       <% if current_user == @cafetype.user %>
         <div class="prototype__manage">
           <%= link_to "編集する", edit_cafetype_path(@cafetype), class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
         <% end %>
-      <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
+      
       <div class="prototype__image">
         <%= image_tag @cafetype.image %>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,7 @@ ja:
         catch_copy: キャッチコピー
         block_number: 番地
         cafe_price: コーヒー価格
-        power_supply: 電源
-        capacity: 席数
-        toilet_place: トイレの場所
+        power_supply_id: 電源
+        capacity_id: 席数
+        toilet_place_id: トイレの場所
+        

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   get 'cafetypes/index'
   root to: "cafetypes#index"
-  resources :cafetypes, only: [:index, :new, :create, :show]
+  resources :cafetypes, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# what
投稿編集画面の作成

# why
投稿編集機能を実装するため

# 動画
- ログイン状態の投稿者は、商品情報編集ページに遷移できる動画
https://gyazo.com/2216b7e2cbf9b3c0716b16f9be3b8bd0

- 必要な情報を適切に入力して「保存する」ボタンを押すと、店舗情報を編集できる動画
https://gyazo.com/e68d0779e4c74579af974966efcad8b9

- 入力に問題がある状態で「保存する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/1b489936602fa9a70091e1c4af4b99cd

- 何も編集せずに「保存する」ボタンを押しても、画像無しの店舗にならない動画
https://gyazo.com/873c200f077c03053c35228ea89a590e

- ログイン状態の場合でも、URLを直接入力して自身が投稿していない店舗の情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/69158a967d6dec913ff42892d79681f3

- ログアウト状態の場合は、URLを直接入力して店舗情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/131d36da4dff30b4cf78ca67c23013ff

- 店舗名や電源情報など、すでに登録されている店舗情報は投稿情報編集画面を開いた時点で表示される動画（店舗画像に関しては、表示されない状態で良い）
https://gyazo.com/9ef8891c09cf9ba5f05254eb552781b0
